### PR TITLE
Jobs overview

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1,8 +1,35 @@
 .navbar_logo {
-    width: 60px;
+	width: 60px;
 }
 
 .link {
-    font-weight: 600;
-    letter-spacing: 1px;
+	font-weight: 600;
+	letter-spacing: 1px;
+}
+
+.th-tile {
+	user-select: none;
+}
+
+.th-tile:hover {
+	cursor: pointer;
+	background-color: #dee2e6;
+}
+
+.cleaning-date {
+	min-width: 130px;
+}
+
+.th-hours-width {
+	width: 80px;
+}
+
+.jobs {
+	max-width: 1500px;
+}
+
+@media (min-width: 576px) {
+	.time-input-label {
+		display: inline-block;
+	}
 }

--- a/client/src/components/CreateJob/SelectCustomer.js
+++ b/client/src/components/CreateJob/SelectCustomer.js
@@ -34,7 +34,7 @@ const SelectCustomer = ({ state, setState, error }) => {
 					worker: state.worker || (data.worker_name ?? null),
 					worker_id: state.worker_id || (data.worker_id ?? null),
 					visit_time: data.visit_time ?? null,
-					duration: data.duration ?? null,
+					duration: data.duration ?? "1",
 				});
 			})
 			.catch((e) => console.log(e));

--- a/client/src/components/Jobs/DateFilter.js
+++ b/client/src/components/Jobs/DateFilter.js
@@ -1,0 +1,47 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+const DateFilter = ({ state, setState }) => {
+	const handleDateChange = (e) => {
+		setState({
+			...state,
+			[e.target.name]: e.target.value,
+		});
+	};
+
+	const { start_time, end_time } = state;
+
+	return (
+		<div className="mb-1">
+			<label htmlFor="start_time" className="mr-3">
+				<div className="time-input-label">From: </div>
+				<input
+					type="date"
+					id="start_time"
+					name="start_time"
+					value={start_time}
+					onChange={handleDateChange}
+					className="ml-1"
+				/>
+			</label>
+			<label htmlFor="end_time" className="ml-sm-4">
+				<div className="time-input-label">To: </div>
+				<input
+					type="date"
+					id="end_time"
+					name="end_time"
+					value={end_time}
+					onChange={handleDateChange}
+					className="ml-1"
+				/>
+			</label>
+		</div>
+	);
+};
+
+DateFilter.propTypes = {
+	state: PropTypes.object.isRequired,
+	setState: PropTypes.func.isRequired,
+};
+
+export default DateFilter;

--- a/client/src/components/Jobs/JobsList.js
+++ b/client/src/components/Jobs/JobsList.js
@@ -1,24 +1,88 @@
-import React from "react";
+import React, { useState } from "react";
 import { Table } from "reactstrap";
 import useFetch from "../../hooks/useFetch";
 import Spinner from "../UI/Spinner";
 import JobsTableHead from "./JobsTableHead";
 import JobsTableBody from "./JobsTableBody";
+import DateFilter from "./DateFilter";
+import StatusFilter from "./StatusFilter";
+import { sortByField } from "../../util/helpers";
 
 const JobsList = () => {
 	const { data, error, isLoading } = useFetch("/jobs");
+	const [state, setState] = useState({
+		start_time: "",
+		end_time: "",
+		status: "",
+	});
+	const [sortBy, setSortBy] = useState("visit_on");
+	const [isAscending, setIsAscending] = useState(null);
+
+	const { start_time, end_time, status } = state;
+
+	const filterByDate = (jobs) => {
+		const afterStartTime = (time) => {
+			if (!start_time) {
+				return true;
+			}
+			const visitTime = new Date(time).getTime();
+			const startTime = new Date(start_time).getTime();
+			return visitTime >= startTime;
+		};
+
+		const beforeEndTime = (time) => {
+			if (!end_time) {
+				return true;
+			}
+			const visitTime = new Date(time).getTime();
+			const endTime = new Date(end_time).getTime();
+			return visitTime <= endTime;
+		};
+
+		return jobs.filter(
+			(job) => afterStartTime(job.visit_on) && beforeEndTime(job.visit_on)
+		);
+	};
+
+	const filterByStatus = (jobs) => {
+		if (status === "") {
+			return jobs;
+		}
+
+		return jobs.filter((job) => job.status === status);
+	};
+
+	const changeSearchField = (field) => {
+		if (sortBy === field) {
+			// toggling A-Z and Z-A on the same column
+			setIsAscending(!isAscending);
+		} else {
+			// when clicked on different column sort ascending
+			setIsAscending(true);
+		}
+		setSortBy(field);
+	};
 
 	if (error) {
-		return <div>Error</div>;
+		return <div>Oops, something went wrong.</div>;
 	} else if (isLoading) {
 		return <Spinner />;
 	} else if (data) {
+		const filteredDataByDate = filterByDate(data.jobs);
+		const filteredDataByStatus = filterByStatus(filteredDataByDate);
+		const sortedData = sortByField(filteredDataByStatus, sortBy, isAscending);
+
 		return (
 			<div>
+				<div className="d-flex justify-content-between">
+					<DateFilter state={state} setState={setState} />
+					<StatusFilter state={state} setState={setState} />
+				</div>
 				<Table striped hover responsive>
-					<JobsTableHead />
-					<JobsTableBody data={data} />
+					<JobsTableHead changeSearchField={changeSearchField} />
+					<JobsTableBody data={sortedData} />
 				</Table>
+				{sortedData.length === 0 && <div>No matches</div>}
 			</div>
 		);
 	}

--- a/client/src/components/Jobs/JobsTableBody.js
+++ b/client/src/components/Jobs/JobsTableBody.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { useHistory } from "react-router-dom";
+import SelectIcon from "../UI/SelectIcon";
 
 const JobsTableBody = ({ data }) => {
 	const history = useHistory();
@@ -29,8 +30,21 @@ const JobsTableBody = ({ data }) => {
 
 	return (
 		<tbody>
-			{data.jobs.map(
-				({ id, customer, address, worker, date_created, visit_on, status }) => (
+			{data.map(
+				({
+					id,
+					customer,
+					address,
+					worker,
+					visit_on,
+					status,
+					visit_time,
+					visit_end,
+					duration,
+					start_time,
+					end_time,
+					actual_duration,
+				}) => (
 					<tr
 						key={id}
 						role="button"
@@ -38,12 +52,23 @@ const JobsTableBody = ({ data }) => {
 						onKeyPress={(e) => handleKeyPress(id, e)}
 						tabIndex={0}
 					>
-						<th scope="row">{customer}</th>
+						<td className={"text-center"}>
+							{status ? (
+								<SelectIcon type="success" />
+							) : (
+								<SelectIcon type="warning" />
+							)}
+						</td>
+						<td>{customer}</td>
 						<td>{address}</td>
 						<td>{worker}</td>
-						<td>{formatDate(date_created)}</td>
 						<td>{formatDate(visit_on)}</td>
-						<td>{status ? "Submitted" : "Not submitted"}</td>
+						<td>{visit_time}</td>
+						<td>{visit_end}</td>
+						<td>{duration}</td>
+						<td>{start_time}</td>
+						<td>{end_time}</td>
+						<td>{actual_duration}</td>
 					</tr>
 				)
 			)}
@@ -52,7 +77,7 @@ const JobsTableBody = ({ data }) => {
 };
 
 JobsTableBody.propTypes = {
-	data: PropTypes.object,
+	data: PropTypes.array,
 };
 
 export default JobsTableBody;

--- a/client/src/components/Jobs/JobsTableHead.js
+++ b/client/src/components/Jobs/JobsTableHead.js
@@ -1,18 +1,72 @@
 import React from "react";
+import PropTypes from "prop-types";
 
-const JobsTableHead = () => {
+const JobsTableHead = ({ changeSearchField }) => {
 	return (
 		<thead>
 			<tr>
-				<th>Customer</th>
-				<th>Address</th>
-				<th>Cleaner</th>
-				<th>Time created</th>
-				<th>Cleaning date</th>
-				<th>Status</th>
+				<th
+					className="th-tile"
+					onClick={() => changeSearchField("status")}
+				></th>
+				<th className="th-tile" onClick={() => changeSearchField("customer")}>
+					Customer
+				</th>
+				<th className="th-tile" onClick={() => changeSearchField("address")}>
+					Address
+				</th>
+				<th className="th-tile" onClick={() => changeSearchField("worker")}>
+					Cleaner
+				</th>
+				<th
+					className="th-tile cleaning-date"
+					onClick={() => changeSearchField("visit_on")}
+				>
+					Cleaning date
+				</th>
+				<th
+					className="th-tile th-hours-width"
+					onClick={() => changeSearchField("visit_time")}
+				>
+					Planned start
+				</th>
+				<th
+					className="th-tile th-hours-width"
+					onClick={() => changeSearchField("visit_end")}
+				>
+					Planned end
+				</th>
+				<th
+					className="th-tile th-hours-width"
+					onClick={() => changeSearchField("duration")}
+				>
+					Planned duration
+				</th>
+				<th
+					className="th-tile th-hours-width"
+					onClick={() => changeSearchField("start_time")}
+				>
+					Actual start
+				</th>
+				<th
+					className="th-tile th-hours-width"
+					onClick={() => changeSearchField("end_time")}
+				>
+					Actual end
+				</th>
+				<th
+					className="th-tile th-hours-width"
+					onClick={() => changeSearchField("actual_duration")}
+				>
+					Actual duration
+				</th>
 			</tr>
 		</thead>
 	);
+};
+
+JobsTableHead.propTypes = {
+	changeSearchField: PropTypes.func,
 };
 
 export default JobsTableHead;

--- a/client/src/components/Jobs/StatusFilter.js
+++ b/client/src/components/Jobs/StatusFilter.js
@@ -1,0 +1,41 @@
+import React from "react";
+import { FormGroup, Label, Input } from "reactstrap";
+import PropTypes from "prop-types";
+
+const StatusFilter = ({ state, setState }) => {
+	const handleChange = (e) => {
+		const { value } = e.target;
+		const status = value ? Number(value) : value;
+
+		setState({
+			...state,
+			status,
+		});
+	};
+
+	return (
+		<FormGroup>
+			<Label for="statusSelect" hidden>
+				Status
+			</Label>
+			<Input
+				type="select"
+				name="statusSelect"
+				id="statusSelect"
+				onChange={handleChange}
+				bsSize="sm"
+			>
+				<option value="">All</option>
+				<option value={1}>Completed</option>
+				<option value={0}>Missing</option>
+			</Input>
+		</FormGroup>
+	);
+};
+
+StatusFilter.propTypes = {
+	state: PropTypes.object.isRequired,
+	setState: PropTypes.func.isRequired,
+};
+
+export default StatusFilter;

--- a/client/src/components/UI/SelectIcon.js
+++ b/client/src/components/UI/SelectIcon.js
@@ -1,0 +1,23 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+const SelectIcon = ({ type }) => {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			width="16"
+			height="16"
+			fill="currentColor"
+			className={`bi bi-circle-fill text-${type}`}
+			viewBox="0 0 16 16"
+		>
+			<circle cx="8" cy="8" r="8" />
+		</svg>
+	);
+};
+
+SelectIcon.propTypes = {
+	type: PropTypes.string,
+};
+
+export default SelectIcon;

--- a/client/src/pages/Jobs.js
+++ b/client/src/pages/Jobs.js
@@ -4,7 +4,7 @@ import { JobsList, AddNewButton } from "../components";
 
 const Jobs = () => {
 	return (
-		<Container>
+		<Container fluid={true} className="pr-lg-5 pl-lg-5 jobs">
 			<h2 className="text-center mt-4 mt-md-5 mb-5 mb-md-5">Jobs</h2>
 			<AddNewButton pathname="/create-job" />
 			<JobsList />

--- a/client/src/util/helpers.js
+++ b/client/src/util/helpers.js
@@ -8,3 +8,20 @@ export const sortDescByABC = (array, field) => {
 		}
 	});
 };
+
+// sort array of objects by specified field and order
+export const sortByField = (array, field, isAscending) => {
+	return array.sort((res1, res2) => {
+		if (typeof res1[field] === "string") {
+			// string sort
+			return isAscending
+				? res1[field]?.localeCompare(res2[field])
+				: res2[field]?.localeCompare(res1[field]);
+		} else {
+			// number sort
+			return isAscending
+				? res1[field] - res2[field]
+				: res2[field] - res1[field];
+		}
+	});
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -6507,6 +6507,11 @@
         "yallist": "^4.0.0"
       }
     },
+    "luxon": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.25.0.tgz",
+      "integrity": "sha512-hEgLurSH8kQRjY6i4YLey+mcKVAWXbDNlZRmM6AgWDJ1cY3atl8Ztf5wEY7VBReFbmGnwQPz7KYJblL8B2k0jQ=="
+    },
     "make-dir": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "express": "^4.17.1",
     "express-validator": "^6.8.0",
     "helmet": "^4.2.0",
+    "luxon": "^1.25.0",
     "morgan": "^1.10.0",
     "pg": "^8.5.1",
     "react-router-dom": "^5.2.0",

--- a/server/routes/jobs.js
+++ b/server/routes/jobs.js
@@ -2,6 +2,7 @@
 import { Router } from "express";
 import { body, check, validationResult } from "express-validator";
 import db from "../db";
+import formatJobs from "../util/formatJobs";
 
 const router = new Router();
 
@@ -29,14 +30,14 @@ router.get("/jobs/:id", (req, res, next) => {
 
 router.get("/jobs", (_, res, next) => {
 	db.query(
-		`SELECT j.id, j.status, j.date_created,b.address, j.visit_on, j.visit_time, j.pay_rate, j.details, j.start_time, j.end_time, c.name customer, w.name worker
+		`SELECT j.*, b.address, c.name customer, w.name worker
 		FROM jobs j 
 		INNER JOIN branches b ON j.branch_id=b.id 
 		INNER JOIN customers c ON j.customer_id=c.id
 		INNER JOIN workers w ON w.id=j.worker_id`
 	)
 		.then(({ rows }) => {
-			return res.json({ jobs: rows });
+			return res.json({ jobs: formatJobs(rows) });
 		})
 		.catch((e) => {
 			console.error(e);

--- a/server/spring_action_cleaning.sql
+++ b/server/spring_action_cleaning.sql
@@ -140,5 +140,5 @@ insert into admins (name, email, password) values ('Agustin Challenger', 'achall
 
 insert into jobs (date_created, customer_id, branch_id , worker_id, unique_url, visit_on, visit_time, pay_rate) values ('2020-12-09', 1, 1, 1, 'hsuJJU88Hi', '2020-12-21', '15:20', 10);
 insert into jobs (date_created, customer_id, branch_id , worker_id, unique_url, visit_on, visit_time, pay_rate) values ('2020-12-09', 2, 22, 2, 'ji2298Hi9w', '2020-12-12', '15:20', 10);
-insert into jobs (date_created, customer_id, branch_id , worker_id, unique_url, visit_on, visit_time, pay_rate) values ('2020-12-09', 3, 3, 7, 'fvwei99ee9', '2020-12-12', '15:20', 10.5);
-insert into jobs (date_created, customer_id, branch_id , worker_id, visit_on, visit_time, pay_rate) values ('2020-12-09', 4, 4, 3, '2020-12-12', '15:20', 10.5);
+insert into jobs (date_created, customer_id, branch_id , worker_id, unique_url, visit_on, visit_time, pay_rate, duration) values ('2020-12-09', 3, 3, 7, 'fvwei99ee9', '2020-12-12', '15:20', 10.5, 2);
+insert into jobs (date_created, customer_id, branch_id , worker_id, visit_on, visit_time, pay_rate, duration) values ('2020-12-09', 4, 4, 3, '2020-12-12', '15:20', 10.5, 2);

--- a/server/util/formatJobs.js
+++ b/server/util/formatJobs.js
@@ -1,0 +1,53 @@
+import { DateTime } from "luxon";
+
+const formatJobs = (jobs) =>
+	jobs.map((job) => ({
+		...job,
+		visit_time: formatHours(job.visit_time),
+		visit_end: countVisitEnd(job.visit_time, job.duration),
+		duration: intToHours(job.duration),
+		start_time: formatHours(job.start_time),
+		end_time: formatHours(job.end_time),
+		actual_duration: countActualDuration(job.start_time, job.end_time),
+	}));
+
+const countActualDuration = (startTime, endTime) => {
+	if (!startTime || !endTime) {
+		return null;
+	}
+
+	const end = DateTime.fromSQL(endTime);
+	const start = DateTime.fromSQL(startTime);
+	const difference = end.diff(start, ["hours", "minutes"]);
+	const result = DateTime.fromObject(difference.values).toFormat("HH:mm");
+
+	return result;
+};
+
+const formatHours = (hoursWithSeconds) => {
+	if (!hoursWithSeconds) {
+		return null;
+	}
+
+	return DateTime.fromSQL(hoursWithSeconds).toFormat("HH:mm");
+};
+
+const countVisitEnd = (startTime, duration) => {
+	if (!duration) {
+		return null;
+	}
+
+	return DateTime.fromSQL(startTime)
+		.plus({ hours: duration })
+		.toFormat("HH:mm");
+};
+
+const intToHours = (numberOfHours) => {
+	if (!numberOfHours) {
+		return null;
+	}
+
+	return `${numberOfHours < 10 ? `0${numberOfHours}` : numberOfHours}:00`;
+};
+
+export default formatJobs;


### PR DESCRIPTION
### Proposal
Add filtering for jobs by date range and / or status of the job. Also add table columns for planned start / end / duration times and actual start / end / duration times.

This would close [this](https://trello.com/c/Zl04hwIM/76-jobs-overview-add-date-filter-to-jobs-list), [this](https://trello.com/c/X5tdMQu7/75-jobs-overview-show-planned-and-actual-start-and-end-times-on-job-list) and [this](https://trello.com/c/wPSyRtGZ/78-jobs-overview-calculate-actual-duration-of-job-and-display-on-jobs-list) Trello ticket.

### Checklist

- [x] I have made this pull request to the `master` branch
- [x] I have run `npm run lint` and there are no errors
