### PR TITLE
Missed jobs indicator

### DIFF
--- a/client/src/components/Jobs/JobsTableBody.js
+++ b/client/src/components/Jobs/JobsTableBody.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { useHistory } from "react-router-dom";
-import SelectIcon from "../UI/SelectIcon";
+import StatusIndicator from "./StatusIndicator";
 
 const JobsTableBody = ({ data }) => {
 	const history = useHistory();
@@ -53,11 +53,7 @@ const JobsTableBody = ({ data }) => {
 						tabIndex={0}
 					>
 						<td className={"text-center"}>
-							{status ? (
-								<SelectIcon type="success" />
-							) : (
-								<SelectIcon type="warning" />
-							)}
+							<StatusIndicator status={status} date={visit_on} />
 						</td>
 						<td>{customer}</td>
 						<td>{address}</td>

--- a/client/src/components/Jobs/StatusIndicator.js
+++ b/client/src/components/Jobs/StatusIndicator.js
@@ -1,0 +1,17 @@
+import React from "react";
+import SelectIcon from "../UI/SelectIcon";
+import { determineJobStatus } from "../../util/helpers";
+
+const StatusIndicator = ({ status, date }) => {
+	const jobStatus = determineJobStatus(status, date);
+
+	if (jobStatus === "completed") {
+		return <SelectIcon type="success" />;
+	} else if (jobStatus === "awaiting") {
+		return <SelectIcon type="warning" />;
+	} else {
+		return <SelectIcon type="danger" />;
+	}
+};
+
+export default StatusIndicator;

--- a/client/src/util/helpers.js
+++ b/client/src/util/helpers.js
@@ -1,3 +1,5 @@
+import { DateTime } from "luxon";
+
 // sort array of objects for specified field
 export const sortAscByABC = (array, field) => {
 	return array.sort((first, second) => {
@@ -24,4 +26,19 @@ export const sortByField = (array, field, isAscending) => {
 				: res2[field] - res1[field];
 		}
 	});
+};
+
+export const determineJobStatus = (status, date) => {
+	if (status === 1) {
+		return "completed";
+	}
+
+	const today = DateTime.local().minus({ days: 1 });
+	const visitDate = DateTime.fromISO(date);
+
+	if (visitDate < today) {
+		return "missed";
+	} else {
+		return "awaiting";
+	}
 };

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -1,4 +1,8 @@
-import { sortAscByABC, sortByField } from "../client/src/util/helpers";
+import {
+	sortAscByABC,
+	sortByField,
+	determineJobStatus,
+} from "../client/src/util/helpers";
 
 describe("Client side helper functions", () => {
 	test("sortAscByABC sorts array of objects ascending by abc", () => {
@@ -59,5 +63,22 @@ describe("Client side helper functions", () => {
 			{ foo: "Z", num: 2 },
 		];
 		expect(sortByField(arrayToSort, "num", true)).toStrictEqual(sortedArray);
+	});
+
+	test("", () => {});
+
+	test("determineJobStatus() works as expected", () => {
+		// taken from https://codewithhugo.com/mocking-the-current-date-in-jest-tests/
+		jest
+			.spyOn(global.Date, "now")
+			.mockImplementationOnce(() =>
+				new Date("2021-01-06T11:01:58.135Z").valueOf()
+			);
+
+		expect(determineJobStatus(0, "2021-01-05")).toBe("missed");
+		expect(determineJobStatus(0, "2021-01-06")).toBe("awaiting");
+		expect(determineJobStatus(0, "2020-01-01")).toBe("missed");
+		expect(determineJobStatus(1, "2020-01-05")).toBe("completed");
+		expect(determineJobStatus(1, "2020-01-07")).toBe("completed");
 	});
 });


### PR DESCRIPTION
### Proposal
Added one more colour to our job status indicator icon. If the job is from yesterday or older and it is not submitted the icon will be of dark red colour.

So stages are the following:
- job is submitted - green (completed);
- job is not submitted but the date is today or later in the future - orange (awaiting);
- job is not submitted and the date is yesterday or older - dark red (missing);

### Checklist

- [x] I have made this pull request to the `master` branch
- [x] I have run `npm run lint` and there are no errors
