### PR TITLE
Character limits

### DIFF
--- a/client/src/components/CreateCustomer/BranchForm.js
+++ b/client/src/components/CreateCustomer/BranchForm.js
@@ -130,6 +130,7 @@ const BranchForm = ({
 							onChange={handleChange}
 							value={address}
 							required
+							maxLength={100}
 						/>
 						{errors.address && (
 							<FormText color="danger">{errors.address}</FormText>
@@ -158,6 +159,7 @@ const BranchForm = ({
 							placeholder="Enter contact name"
 							onChange={handleChange}
 							value={contact_name}
+							maxLength={100}
 						/>
 						{errors.contact_name && (
 							<FormText color="danger">{errors.contact_name}</FormText>
@@ -175,6 +177,7 @@ const BranchForm = ({
 							placeholder="Enter Phone Number"
 							onChange={handleChange}
 							value={contact_phone}
+							maxLength={50}
 						/>
 						{errors.contact_phone && (
 							<FormText color="danger">{errors.contact_phone}</FormText>
@@ -239,7 +242,9 @@ const BranchForm = ({
 							value={details}
 							type="textarea"
 							rows={4}
+							maxLength={250}
 						/>
+						<FormText className="text-right">{details.length}/250</FormText>
 						{errors.details && (
 							<FormText color="danger">{errors.details}</FormText>
 						)}

--- a/client/src/components/CreateCustomer/CreateCustomerForm.js
+++ b/client/src/components/CreateCustomer/CreateCustomerForm.js
@@ -89,6 +89,7 @@ const CreateCustomerForm = ({ state, setState }) => {
 							placeholder="Enter name"
 							onChange={handleChange}
 							value={state.name}
+							maxLength={100}
 						/>
 						{errors.name && <FormText color="danger">{errors.name}</FormText>}
 					</FormGroup>
@@ -101,6 +102,7 @@ const CreateCustomerForm = ({ state, setState }) => {
 							placeholder="Enter email"
 							onChange={handleChange}
 							value={state.email}
+							maxLength={60}
 						/>
 						{errors.email && <FormText color="danger">{errors.email}</FormText>}
 					</FormGroup>
@@ -113,6 +115,7 @@ const CreateCustomerForm = ({ state, setState }) => {
 							placeholder="Enter Phone Number"
 							onChange={handleChange}
 							value={state.phone_number}
+							maxLength={50}
 						/>
 						{errors.phone_number && (
 							<FormText color="danger">{errors.phone_number}</FormText>

--- a/client/src/components/CreateJob/DetailsInput.js
+++ b/client/src/components/CreateJob/DetailsInput.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { FormGroup, Label, Input, FormText } from "reactstrap";
 
-const DetailsInput = ({ state, setState }) => {
+const DetailsInput = ({ state, setState, error }) => {
 	const handleChange = (e) => {
 		setState({
 			...state,
@@ -26,6 +26,7 @@ const DetailsInput = ({ state, setState }) => {
 					rows={4}
 				/>
 				<FormText className="text-right">{state.details.length}/500</FormText>
+				{error && <FormText color="danger">{error}</FormText>}
 			</FormGroup>
 		</div>
 	);
@@ -34,6 +35,7 @@ const DetailsInput = ({ state, setState }) => {
 DetailsInput.propTypes = {
 	state: PropTypes.object.isRequired,
 	setState: PropTypes.func.isRequired,
+	error: PropTypes.string,
 };
 
 export default DetailsInput;

--- a/client/src/components/CreateJob/DetailsInput.js
+++ b/client/src/components/CreateJob/DetailsInput.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { FormGroup, Label, Input } from "reactstrap";
+import { FormGroup, Label, Input, FormText } from "reactstrap";
 
 const DetailsInput = ({ state, setState }) => {
 	const handleChange = (e) => {
@@ -22,8 +22,10 @@ const DetailsInput = ({ state, setState }) => {
 					id="details"
 					value={state.details || ""}
 					onChange={handleChange}
+					maxLength={500}
 					rows={4}
 				/>
+				<FormText className="text-right">{state.details.length}/500</FormText>
 			</FormGroup>
 		</div>
 	);

--- a/client/src/components/CreateWorkerForm.js
+++ b/client/src/components/CreateWorkerForm.js
@@ -107,6 +107,7 @@ const CreateWorkerForm = ({
 							placeholder="Enter full name"
 							onChange={handleChange}
 							value={state.name}
+							maxLength={100}
 						/>
 						{errors.name && <FormText color="danger">{errors.name}</FormText>}
 					</FormGroup>
@@ -120,6 +121,7 @@ const CreateWorkerForm = ({
 							placeholder="Enter email"
 							onChange={handleChange}
 							value={state.email}
+							maxLength={60}
 						/>
 						{errors.email && <FormText color="danger">{errors.email}</FormText>}
 					</FormGroup>
@@ -133,6 +135,7 @@ const CreateWorkerForm = ({
 							placeholder="Enter address"
 							onChange={handleChange}
 							value={state.address}
+							maxLength={100}
 						/>
 						{errors.address && (
 							<FormText color="danger">{errors.address}</FormText>
@@ -148,6 +151,7 @@ const CreateWorkerForm = ({
 							placeholder="Enter phone number"
 							onChange={handleChange}
 							value={state.phone}
+							maxLength={50}
 						/>
 						{errors.phone && <FormText color="danger">{errors.phone}</FormText>}
 					</FormGroup>
@@ -161,6 +165,7 @@ const CreateWorkerForm = ({
 							placeholder="Enter whatsapp"
 							onChange={handleChange}
 							value={state.whatsapp}
+							maxLength={50}
 						/>
 						{errors.whatsapp && (
 							<FormText color="danger">{errors.whatsapp}</FormText>

--- a/client/src/components/Jobs/Worker/WorkerLogTimeForm.js
+++ b/client/src/components/Jobs/Worker/WorkerLogTimeForm.js
@@ -81,7 +81,7 @@ const WorkerLogTimeForm = ({ id, start_time, end_time, worker_feedback }) => {
 				/>
 				{errors.endTime && <FormText color="danger">{errors.endTime}</FormText>}
 			</FormGroup>
-			<FormGroup>
+			<FormGroup className="mb-4">
 				<Label for="feedback">Details</Label>
 				<Input
 					type="textarea"
@@ -91,7 +91,9 @@ const WorkerLogTimeForm = ({ id, start_time, end_time, worker_feedback }) => {
 					value={feedback}
 					onChange={handleChange}
 					rows={4}
+					maxLength={500}
 				/>
+				<FormText className="text-right">{feedback.length}/500</FormText>
 			</FormGroup>
 			<div className="d-flex justify-content-between">
 				<Button type="submit">Submit</Button>

--- a/client/src/components/Jobs/Worker/WorkerLogTimeForm.js
+++ b/client/src/components/Jobs/Worker/WorkerLogTimeForm.js
@@ -94,6 +94,9 @@ const WorkerLogTimeForm = ({ id, start_time, end_time, worker_feedback }) => {
 					maxLength={500}
 				/>
 				<FormText className="text-right">{feedback.length}/500</FormText>
+				{errors.feedback && (
+					<FormText color="danger">{errors.feedback}</FormText>
+				)}
 			</FormGroup>
 			<div className="d-flex justify-content-between">
 				<Button type="submit">Submit</Button>

--- a/client/src/pages/CreateJob.js
+++ b/client/src/pages/CreateJob.js
@@ -143,7 +143,11 @@ const Jobs = ({
 						error={errors.pay_rate}
 					/>
 				</div>
-				<DetailsInput state={state} setState={setState} />
+				<DetailsInput
+					state={state}
+					setState={setState}
+					error={errors.details}
+				/>
 				<hr />
 				<WorkerFeedback feedback={feedback} />
 				<div className="border rounded-lg p-3 mb-5">

--- a/client/src/scss/index.scss
+++ b/client/src/scss/index.scss
@@ -11,6 +11,10 @@ main {
 	margin-bottom: 10rem;
 }
 
+p {
+	white-space: pre-wrap;
+}
+
 .navbar {
 	min-height: 78px;
 	padding: 0 2rem;

--- a/server/routes/branches.js
+++ b/server/routes/branches.js
@@ -89,7 +89,9 @@ router.post(
 	checkPermission("post:branches/:customerId"),
 	[
 		body("address", "Address is required").not().isEmpty(),
+		body("address", "Max length is 100 characters").isLength({ max: 100 }),
 		body("contact_name", "Contact name is required").exists(),
+		body("contact_name", "Max length is 100 characters").isLength({ max: 100 }),
 		body("contact_phone", "Not a valid GB number").custom(
 			(value) =>
 				value === "" ||
@@ -97,9 +99,10 @@ router.post(
 		),
 		body("contact_phone", "Contact phone is required").exists(),
 		body("details", "Details is required").exists(),
+		body("details", "Max length is 250 characters").isLength({ max: 250 }),
 		body(
 			"main_branch",
-			"Specifying if branch is main or not is required"
+			"Specifying if a branch is main or not is required"
 		).exists(),
 	],
 	async (req, res, next) => {
@@ -173,7 +176,9 @@ router.put(
 	checkPermission("put:branches/:customerId/:branchId"),
 	[
 		body("address", "Address is required").not().isEmpty(),
+		body("address", "Max length is 100 characters").isLength({ max: 100 }),
 		body("contact_name", "Contact name is required").exists(),
+		body("contact_name", "Max length is 100 characters").isLength({ max: 100 }),
 		body("contact_phone", "Not a valid GB number").custom(
 			(value) =>
 				value === "" ||
@@ -181,6 +186,7 @@ router.put(
 		),
 		body("contact_phone", "Contact number is required").exists(),
 		body("details", "Details is required").exists(),
+		body("details", "Max length is 250 characters").isLength({ max: 250 }),
 		body(
 			"main_branch",
 			"Specifying if branch is main or not is required"

--- a/server/routes/customers.js
+++ b/server/routes/customers.js
@@ -47,7 +47,9 @@ router.post(
 	checkPermission("post:customers"),
 	[
 		body("email", "Please provide a valid email").isEmail(),
+		body("email", "Max length is 60 characters").isLength({ max: 60 }),
 		body("name", "Name is required").not().isEmpty(),
+		body("name", "Max length is 100 characters").isLength({ max: 100 }),
 		body("phone_number", "Not a valid GB number").custom((value) =>
 			phoneUtil.isValidNumberForRegion(phoneUtil.parse(value, "GB"), "GB")
 		),
@@ -89,7 +91,9 @@ router.put(
 	checkPermission("put:customers/:id"),
 	[
 		body("email", "Please provide a valid email").isEmail(),
+		body("email", "Max length is 60 characters").isLength({ max: 60 }),
 		body("name", "Name is required").not().isEmpty(),
+		body("name", "Max length is 100 characters").isLength({ max: 100 }),
 		body("phone_number", "Not a valid GB number").custom((value) =>
 			phoneUtil.isValidNumberForRegion(phoneUtil.parse(value, "GB"), "GB")
 		),

--- a/server/routes/jobs.js
+++ b/server/routes/jobs.js
@@ -213,6 +213,7 @@ router.post(
 		body("worker_id", "Worker id is required").exists(),
 		body("worker", "Cleaner is required").not().isEmpty(),
 		body("details", "Details are required").exists(),
+		body("details", "Max length is 500 characters").isLength({ max: 500 }),
 		body("visit_on", "Visit date is required").not().isEmpty(),
 		body(
 			"visit_time",
@@ -355,6 +356,7 @@ router.put(
 		body("branch_id", "Please provide a branch id").not().isEmpty(),
 		body("worker_id", "Please provide a worker id").not().isEmpty(),
 		body("details", "Details is required").exists(),
+		body("details", "Max length is 500 characters").isLength({ max: 500 }),
 		body("visit_on", "Visit date is required").not().isEmpty(),
 		body(
 			"visit_time",
@@ -466,6 +468,7 @@ router.put(
 				DateTime.fromISO(value) < DateTime.fromISO(req.body.endTime) ||
 				(value === "" && req.body.endTime === "")
 		),
+		body("feedback", "Max length is 500 characters").isLength({ max: 500 }),
 	],
 	(req, res, next) => {
 		const errors = validationResult(req);

--- a/server/routes/workers.js
+++ b/server/routes/workers.js
@@ -101,13 +101,17 @@ router.post(
 	checkPermission("post:workers"),
 	[
 		body("email", "Please provide a valid email").isEmail().normalizeEmail(),
+		body("email", "Max length is 60 characters").isLength({ max: 60 }),
 		body("name", "Name is required").not().isEmpty().trim(),
+		body("name", "Max length is 100 characters").isLength({ max: 100 }),
 		body("address", "Address is required").not().isEmpty().trim(),
+		body("address", "Max length is 100 characters").isLength({ max: 100 }),
 		body("phone", "Not a valid GB number").custom((value) =>
 			phoneUtil.isValidNumberForRegion(phoneUtil.parse(value, "GB"), "GB")
 		),
 		body("phone", "Phone is required").not().isEmpty().trim(),
 		body("whatsapp", "Whatsapp is required").not().isEmpty().trim(),
+		body("whatsapp", "Max length is 50 characters").isLength({ max: 50 }),
 		body("contract", "Contract is required").isBoolean(),
 	],
 	(req, res, next) => {
@@ -145,13 +149,17 @@ router.put(
 	checkPermission("put:workers"),
 	[
 		body("email", "Please provide a valid email").isEmail().normalizeEmail(),
+		body("email", "Max length is 60 characters").isLength({ max: 60 }),
 		body("name", "Name is required").not().isEmpty().trim(),
+		body("name", "Max length is 100 characters").isLength({ max: 100 }),
 		body("address", "Address is required").not().isEmpty().trim(),
+		body("address", "Max length is 100 characters").isLength({ max: 100 }),
 		body("phone", "Not a valid GB number").custom((value) =>
 			phoneUtil.isValidNumberForRegion(phoneUtil.parse(value, "GB"), "GB")
 		),
 		body("phone", "Phone is required").not().isEmpty().trim(),
 		body("whatsapp", "Whatsapp is required").not().isEmpty().trim(),
+		body("whatsapp", "Max length is 50 characters").isLength({ max: 50 }),
 		body("contract", "Contract is required").isBoolean(),
 	],
 	(req, res, next) => {

--- a/server/spring_action_cleaning.sql
+++ b/server/spring_action_cleaning.sql
@@ -7,7 +7,7 @@ drop table if exists customers;
 CREATE TABLE workers (
   id                    SERIAL PRIMARY KEY,
   name                  VARCHAR(100) NOT NULL,
-  address               VARCHAR(200) NOT NULL,
+  address               VARCHAR(100) NOT NULL,
   email                 VARCHAR(60) NOT NULL UNIQUE,
   phone_number          VARCHAR(50) NOT NULL,
   whatsapp              VARCHAR(50) NOT NULL,
@@ -23,7 +23,7 @@ CREATE TABLE customers (
 
 CREATE TABLE branches (
   id              SERIAL PRIMARY KEY,
-  address         VARCHAR(200) NOT NULL,
+  address         VARCHAR(100) NOT NULL,
   contact_name    VARCHAR(100) NOT NULL,
   contact_phone   VARCHAR(50) NOT NULL,
   details         VARCHAR(250),


### PR DESCRIPTION
### Proposal
Reduced address fields VARCHAR limits in the sql file to 100. I think more of those fields could be reduced. 

Also added `maxLength` limits to `input` and `textarea` otherwise if the input is too long our server would crash and not save the form. It is corresponding to our tables' fields lengths.

For `textarea` also added little info with how many characters used / how many allowed.

`white-space: pre-wrap;` on `p` tag elements will keep the line breaks. Useful when worker will leave comment with time submission and then for admin it will be shown in a `<p>` element with the line breaks preserved.

### Checklist

- [x] I have made this pull request to the `master` branch
- [x] I have run `npm run lint` and there are no errors
