### PR TITLE
Filter recurring jobs by name

### DIFF
--- a/client/src/components/Recurring/WorkerFilter.js
+++ b/client/src/components/Recurring/WorkerFilter.js
@@ -1,0 +1,61 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { FormGroup, Label, Input } from "reactstrap";
+import { sortByField } from "../../util/helpers";
+
+const WorkerFilter = ({ state, setState }) => {
+	const { workers } = state;
+
+	const handleWorkerChange = (e) => {
+		const { value } = e.target;
+		const { originalJobs } = state;
+
+		if (value === "all") {
+			setState({
+				...state,
+				jobs: originalJobs,
+				selectedWorker: value,
+			});
+		} else {
+			setState({
+				...state,
+				jobs: originalJobs.filter(({ worker }) => worker === value),
+				selectedWorker: value,
+			});
+		}
+	};
+
+	const sortedWorkers = sortByField(workers, "name", true);
+
+	if (sortedWorkers.length < 1) {
+		return null;
+	} else {
+		return (
+			<FormGroup>
+				<Label for="workers" hidden>
+					Select worker
+				</Label>
+				<Input
+					type="select"
+					name="workers"
+					id="workers"
+					onChange={handleWorkerChange}
+				>
+					<option value="all">All</option>
+					{sortedWorkers.map((worker, id) => (
+						<option key={id} value={worker.name}>
+							{worker.name}
+						</option>
+					))}
+				</Input>
+			</FormGroup>
+		);
+	}
+};
+
+WorkerFilter.propTypes = {
+	state: PropTypes.object,
+	setState: PropTypes.func,
+};
+
+export default WorkerFilter;

--- a/client/src/components/index.js
+++ b/client/src/components/index.js
@@ -29,6 +29,7 @@ export { default as BackButton } from "./UI/BackButton";
 export { default as ResultPage } from "./Reports/ResultPage";
 export { default as RecurringJobsTableBody } from "./Recurring/RecurringJobsTableBody";
 export { default as RecurringJobsTableHead } from "./Recurring/RecurringJobsTableHead";
+export { default as WorkerFilter } from "./Recurring/WorkerFilter";
 export { default as WorkerJobsList } from "./Jobs/Worker/WorkerJobsList";
 export { default as WorkerLogTimeForm } from "./Jobs/Worker/WorkerLogTimeForm";
 export { default as WorkerJobInfo } from "./Jobs/Worker/WorkerJobInfo";

--- a/client/src/pages/Recurring.js
+++ b/client/src/pages/Recurring.js
@@ -4,16 +4,25 @@ import { getJobs, postBatchOfJobs, getWorkersSelect } from "../service";
 import { Table, Button, Container } from "reactstrap";
 import DateFilter from "../components/Jobs/DateFilter";
 import { sortByField, setCleaningTimeForNextWeek } from "../util/helpers";
-import { Spinner, Title, BackButton } from "../components";
-import { RecurringJobsTableHead, RecurringJobsTableBody } from "../components";
+import {
+	Spinner,
+	Title,
+	BackButton,
+	RecurringJobsTableHead,
+	RecurringJobsTableBody,
+	WorkerFilter,
+} from "../components";
 import useAuthorizationHeaders from "../hooks/useAuthorizationHeaders";
 import { RecurringJobsContext } from "../contexts/RecurringJobs";
 
 const Recurring = () => {
 	const [state, setState] = useState({
+		originalJobs: [],
 		jobs: [],
 		isLoading: true,
 		error: null,
+		workers: [],
+		selectedWorker: "all",
 	});
 	const [date, setDate] = useContext(RecurringJobsContext);
 	const history = useHistory();
@@ -21,6 +30,12 @@ const Recurring = () => {
 
 	useEffect(() => {
 		let isActive = true;
+
+		const filterBySelectedWorker = (jobs, selectedWorker) => {
+			return selectedWorker === "all"
+				? jobs
+				: jobs.filter(({ worker }) => worker === selectedWorker);
+		};
 
 		const fetchJobs = () =>
 			getJobs(date.startDate, date.endDate, authorizationHeaders)
@@ -30,7 +45,11 @@ const Recurring = () => {
 							...state,
 							isLoading: false,
 							error: null,
-							jobs: setCleaningTimeForNextWeek(data.jobs),
+							jobs: filterBySelectedWorker(
+								setCleaningTimeForNextWeek(data.jobs),
+								state.selectedWorker
+							),
+							originalJobs: setCleaningTimeForNextWeek(data.jobs),
 						}));
 					}
 				})
@@ -79,7 +98,10 @@ const Recurring = () => {
 		return (
 			<Container className="pr-lg-5 pl-lg-5 jobs">
 				<Title text="Recreate from previous jobs" />
-				<DateFilter state={date} setState={setDate} />
+				<div className="d-flex justify-content-between">
+					<DateFilter state={date} setState={setDate} />
+					<WorkerFilter state={state} setState={setState} />
+				</div>
 				{sortedJobs.length < 1 ? (
 					<div>No jobs found for the specified time.</div>
 				) : (
@@ -95,7 +117,7 @@ const Recurring = () => {
 						<div className="d-flex justify-content-end mb-4">
 							<BackButton />
 							<Button onClick={handleClick} color="success" className="ml-4">
-								Create {jobs.length} jobs
+								Create {sortedJobs.length} jobs
 							</Button>
 						</div>
 					</>

--- a/client/src/pages/Recurring.js
+++ b/client/src/pages/Recurring.js
@@ -117,7 +117,8 @@ const Recurring = () => {
 						<div className="d-flex justify-content-end mb-4">
 							<BackButton />
 							<Button onClick={handleClick} color="success" className="ml-4">
-								Create {sortedJobs.length} jobs
+								Create {sortedJobs.length} job
+								{sortedJobs.length > 1 && "s"}
 							</Button>
 						</div>
 					</>


### PR DESCRIPTION
### Proposal
Added dropdown with workers names for filtering the jobs for recreation only by selected worker and ignoring the rest.

### Checklist

- [x] I have made this pull request to the `master` branch
- [x] I have run `npm run lint` and there are no errors
