### PR TITLE
CI - run prettier on PR

### DIFF
--- a/.github/workflows/code_format.yml
+++ b/.github/workflows/code_format.yml
@@ -1,0 +1,27 @@
+name: Continuous Integration
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  prettier:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        # Make sure the actual branch is checked out when running on pull requests
+        ref: ${{ github.head_ref }}
+        # This is important to fetch the changes to the previous commit
+        fetch-depth: 0
+
+    - name: Prettify code
+      uses: creyD/prettier_action@v3.1
+      with:
+        # This part is also where you can pass other options, for example:
+        prettier_options: --write **/*.{js,md}
+        only_changed: True
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Proposal
[This github action](https://github.com/marketplace/actions/prettier-action) should run Prettier against all changed files on new pull requests. 

### Checklist

- [x] I have made this pull request to the `master` branch
- [x] I have run `npm run lint` and there are no errors
