### PR TITLE
Fix/report page

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -23,8 +23,8 @@ import {
 	WorkerJobs,
 	WorkerJobPage,
 	HomePage,
+	ReportPage,
 } from "./pages";
-import { ResultPage } from "./components";
 import ContextProviders from "./contexts/ContextProviders";
 
 export function App() {
@@ -76,10 +76,7 @@ export function App() {
 								path="/customers_report"
 								component={CustomerReports}
 							/>
-							<ProtectedRoute
-								path="/result/:type"
-								component={ResultPage}
-							/>
+							<ProtectedRoute path="/result/:type" component={ReportPage} />
 							<ProtectedRoute path="/create-jobs" component={Recurring} />
 						</>
 					)}

--- a/client/src/components/CreateCustomerReport.js
+++ b/client/src/components/CreateCustomerReport.js
@@ -10,11 +10,7 @@ const CreateCustomerReport = () => {
 
 	const handleSubmit = (e) => {
 		e.preventDefault();
-		if(state.customer_id) {
-			history.push(
-				"/result/customer"
-			);
-		}
+		history.push("/result/customer");
 	};
 
 	const handleChange = (e) => {
@@ -49,7 +45,7 @@ const CreateCustomerReport = () => {
 						onChange={handleChange}
 						checked={state.detailed}
 					/>{" "}
-							Detailed
+					Detailed
 				</Label>
 			</div>
 			<div className="d-flex justify-content-end">

--- a/client/src/components/CreateWorkerReport.js
+++ b/client/src/components/CreateWorkerReport.js
@@ -10,11 +10,7 @@ const CreateWorkerReport = () => {
 
 	const handleSubmit = (e) => {
 		e.preventDefault();
-		if(state.worker_id) {
-			history.push(
-				"/result/worker"
-			);
-		}
+		history.push("/result/worker");
 	};
 
 	const handleChange = (e) => {
@@ -49,7 +45,7 @@ const CreateWorkerReport = () => {
 						onChange={handleChange}
 						checked={state.detailed}
 					/>{" "}
-							Detailed
+					Detailed
 				</Label>
 			</div>
 			<div className="d-flex justify-content-end">

--- a/client/src/components/Reports/ResultPage.js
+++ b/client/src/components/Reports/ResultPage.js
@@ -1,22 +1,16 @@
-import React, { useContext } from "react";
+import React from "react";
+import PropTypes from "prop-types";
 import { Container, Table } from "reactstrap";
 import useFetch from "../../hooks/useFetch";
 import { Spinner, Title, BackButton } from "../index";
 import ResultTableHead from "./ResultTableHead";
 import ResultTableBody from "./ResultTableBody";
-import { WorkerReportContext } from "../../contexts/WorkerReport";
-import { CustomerReportContext } from "../../contexts/CustomerReport";
-import { useParams } from "react-router-dom";
 
-const ResultPage = () => {
-	const { type } = useParams();
-	const [state] = useContext([CustomerReportContext, WorkerReportContext][Number(type === "worker")]);
-	const { start_date, finish_date, detailed } = state;
-	const name = [state.customer, state.worker][Number(type === "worker")];
-	const id = [state.customer_id, state.worker_id][Number(type === "worker")];
-
+const ResultPage = ({ start_date, finish_date, detailed, name, id, type }) => {
 	const { data, error, isLoading } = useFetch(
-		`/reports/${type}${detailed ? "_detailed":""}/${id}/${start_date}/${finish_date}`
+		`/reports/${type}${
+			detailed ? "_detailed" : ""
+		}/${id}/${start_date}/${finish_date}`
 	);
 	const total_data = useFetch(
 		`/reports/${type}_total/${id}/${start_date}/${finish_date}`
@@ -37,11 +31,13 @@ const ResultPage = () => {
 					<p>No data for this period.</p>
 				) : (
 					<Table striped hover responsive>
-						<ResultTableHead
-							labels={data.labels}
+						<ResultTableHead labels={data.labels} />
+						<ResultTableBody data={data.rows} type={type} detailed={detailed} />
+						<ResultTableBody
+							data={total_data.data.rows}
+							tableFooter={true}
+							detailed={detailed}
 						/>
-						<ResultTableBody data={data.rows}  type={type} detailed={detailed} />
-						<ResultTableBody data={total_data.data.rows} tableFooter={true} detailed={detailed} />
 					</Table>
 				)}
 				<div className="d-flex justify-content-end mt-5">
@@ -50,6 +46,15 @@ const ResultPage = () => {
 			</Container>
 		);
 	}
+};
+
+ResultPage.propTypes = {
+	start_date: PropTypes.string.isRequired,
+	finish_date: PropTypes.string.isRequired,
+	detailed: PropTypes.bool.isRequired,
+	name: PropTypes.string.isRequired,
+	id: PropTypes.number.isRequired,
+	type: PropTypes.string.isRequired,
 };
 
 export default ResultPage;

--- a/client/src/pages/ReportPage.js
+++ b/client/src/pages/ReportPage.js
@@ -1,0 +1,32 @@
+import React, { useContext } from "react";
+import { useParams, Redirect } from "react-router-dom";
+import { WorkerReportContext } from "../contexts/WorkerReport";
+import { CustomerReportContext } from "../contexts/CustomerReport";
+import ResultPage from "../components/Reports/ResultPage";
+
+const ReportPage = () => {
+	const { type } = useParams();
+	const [state] = useContext(
+		[CustomerReportContext, WorkerReportContext][Number(type === "worker")]
+	);
+	const { start_date, finish_date, detailed } = state;
+	const name = [state.customer, state.worker][Number(type === "worker")];
+	const id = [state.customer_id, state.worker_id][Number(type === "worker")];
+
+	if (id) {
+		return (
+			<ResultPage
+				start_date={start_date}
+				finish_date={finish_date}
+				detailed={detailed}
+				name={name}
+				id={id}
+				type={type}
+			/>
+		);
+	} else {
+		return <Redirect to={`/${type}s_report`} />;
+	}
+};
+
+export default ReportPage;

--- a/client/src/pages/index.js
+++ b/client/src/pages/index.js
@@ -13,3 +13,4 @@ export { default as CustomerReports } from "./CustomerReports";
 export { default as WorkerJobs } from "./WorkerJobs";
 export { default as WorkerJobPage } from "./WorkerJobPage";
 export { default as HomePage } from "./HomePage";
+export { default as ReportPage } from "./ReportPage";


### PR DESCRIPTION
### Proposal
Fixed the broken reports page on page reload. Now it will redirect back to either cleaner's or customer's report selection page.

### Checklist

- [x] I have made this pull request to the `master` branch
- [x] I have run `npm run lint` and there are no errors
