### PR TITLE
Fix/missing duration bug

### DIFF
--- a/client/src/components/CreateCustomer/BranchesTable.js
+++ b/client/src/components/CreateCustomer/BranchesTable.js
@@ -28,11 +28,11 @@ const BranchesTable = ({ state, toggleEditModal, setState, isOpen }) => {
 		// populate BranchForm state for editing branch
 		setState({
 			...state,
-			address: address,
-			contact_phone: contact_phone,
-			details: details ?? "",
-			duration: duration ?? "1",
-			worker_id: worker_id,
+			address,
+			contact_phone,
+			details,
+			duration,
+			worker_id,
 			visit_time: visit_time ?? "",
 			branch_id: branchId,
 		});

--- a/client/src/components/CreateJob/SelectBranch.js
+++ b/client/src/components/CreateJob/SelectBranch.js
@@ -41,7 +41,7 @@ const SelectBranch = ({ state, setState, error }) => {
 					worker: data.worker_name ?? null,
 					worker_id: data.worker_id ?? null,
 					visit_time: data.visit_time ?? null,
-					duration: data.duration ?? null,
+					duration: data.duration,
 					details: data.branch_details,
 				});
 			})

--- a/client/src/components/CreateJob/SelectCustomer.js
+++ b/client/src/components/CreateJob/SelectCustomer.js
@@ -46,7 +46,7 @@ const SelectCustomer = ({ state, setState, error }) => {
 					worker: state.worker || (data.worker_name ?? null),
 					worker_id: state.worker_id || (data.worker_id ?? null),
 					visit_time: data.visit_time ?? null,
-					duration: data.duration ?? "1",
+					duration: data.duration,
 					details: data.branch_details || "",
 				});
 			})

--- a/client/src/components/CreateJob/SelectDuration.js
+++ b/client/src/components/CreateJob/SelectDuration.js
@@ -14,7 +14,7 @@ const SelectDuration = ({ state, setState, error }) => {
 		<div className="mb-3 mb-md-4 mb-lg-5 w-100 mr-3 mr-md-5">
 			<FormGroup>
 				<Label for="duration" size="lg">
-					Duration <span className="text-muted">(optional)</span>
+					Duration
 				</Label>
 				<Input
 					invalid={!!error}
@@ -22,7 +22,8 @@ const SelectDuration = ({ state, setState, error }) => {
 					name="select"
 					id="duration"
 					onChange={handleChange}
-					value={state.duration || "1"}
+					value={state.duration}
+					required
 				>
 					<option value="1">1 hour</option>
 					<option value="2">2 hours</option>

--- a/client/src/components/WorkerJobs/WorkerJobInfo.js
+++ b/client/src/components/WorkerJobs/WorkerJobInfo.js
@@ -37,16 +37,13 @@ const WorkerJobInfo = ({
 				<strong>Contact phone: </strong>
 				{contact_phone}
 			</p>
-
-			{duration && (
-				<p className="worker-info-text-size">
-					<strong>Planned duration:</strong> {duration}{" "}
-					{duration === 1 ? "hour" : "hours"}
-				</p>
-			)}
+			<p className="worker-info-text-size">
+				<strong>Planned duration:</strong> {duration}{" "}
+				{duration === 1 ? "hour" : "hours"}
+			</p>
 			<p className="worker-info-text-size">
 				<strong>Job details: </strong>
-				{details}
+				{details ? details : "—"}
 			</p>
 		</div>
 	);

--- a/server/routes/branches.js
+++ b/server/routes/branches.js
@@ -108,6 +108,8 @@ router.post(
 			"main_branch",
 			"Specifying if a branch is main or not is required"
 		).exists(),
+		body("duration", "Duration is required").exists(),
+		body("duration", "Duration should be an integer").isInt(),
 	],
 	async (req, res, next) => {
 		const errors = validationResult(req);
@@ -199,6 +201,8 @@ router.put(
 			"main_branch",
 			"Specifying if branch is main or not is required"
 		).exists(),
+		body("duration", "Duration is required").exists(),
+		body("duration", "Duration should be an integer").isInt(),
 	],
 	async (req, res, next) => {
 		const errors = validationResult(req);

--- a/server/routes/jobs.js
+++ b/server/routes/jobs.js
@@ -227,6 +227,7 @@ router.post(
 		),
 		body("pay_rate", "Pay rate is required").exists(),
 		body("duration", "Duration is required").exists(),
+		body("duration", "Duration should be an integer").isInt(),
 		body(
 			"start_time",
 			"Start time is not in a format of HH:MM (24h clock)"
@@ -375,6 +376,7 @@ router.put(
 		),
 		body("pay_rate", "Pay rate is required").exists(),
 		body("duration", "Duration is required").exists(),
+		body("duration", "Duration should be an integer").isInt(),
 		body(
 			"start_time",
 			"Start time is not in a format of HH:MM (24h clock)"

--- a/server/spring_action_cleaning.sql
+++ b/server/spring_action_cleaning.sql
@@ -34,7 +34,7 @@ CREATE TABLE branches (
   customer_id     INT REFERENCES customers(id),
   worker_id       INT REFERENCES workers(id),
   visit_time      TIME,
-  duration        INT
+  duration        INT NOT NULL DEFAULT 1
 );
 
 ALTER TABLE customers ADD COLUMN main_branch_id INT REFERENCES branches(id);

--- a/server/spring_action_cleaning.sql
+++ b/server/spring_action_cleaning.sql
@@ -51,7 +51,7 @@ CREATE TABLE jobs (
   status          INT NOT NULL DEFAULT 0,
   start_time      TIME (0),
   end_time        TIME (0),
-  duration        INT,
+  duration        INT NOT NULL DEFAULT 1,
   pay_rate        FLOAT,
   feedback        VARCHAR(500) DEFAULT ''
 );
@@ -122,9 +122,9 @@ UPDATE customers SET main_branch_id=8 WHERE id=8;
 UPDATE customers SET main_branch_id=9 WHERE id=9;
 UPDATE customers SET main_branch_id=10 WHERE id=10;
 
-insert into jobs (date_created, customer_id, branch_id , worker_id, visit_on, visit_time, pay_rate) values ('2020-12-09', 1, 1, 1, '2020-12-21', '15:20', 10);
-insert into jobs (date_created, customer_id, branch_id , worker_id, visit_on, visit_time, pay_rate) values ('2020-12-09', 2, 22, 2, '2021-02-02', '12:10', 10);
-insert into jobs (date_created, customer_id, branch_id , worker_id, visit_on, visit_time, pay_rate) values ('2021-01-15', 2, 2, 2, '2021-01-28', '10:00', 10);
-insert into jobs (date_created, customer_id, branch_id , worker_id, visit_on, visit_time, pay_rate) values ('2021-01-15', 3, 23, 2, '2021-02-04', '12:45', 10);
-insert into jobs (date_created, customer_id, branch_id , worker_id, visit_on, visit_time, pay_rate, duration) values ('2020-12-09', 3, 3, 7, '2020-12-12', '15:20', 10.5, 2);
-insert into jobs (date_created, customer_id, branch_id , worker_id, visit_on, visit_time, pay_rate, duration) values ('2020-12-09', 4, 4, 3, '2020-12-12', '15:20', 10.5, 2);
+insert into jobs (date_created, customer_id, branch_id , worker_id, visit_on, visit_time, pay_rate, duration) values ('2020-12-09', 1, 1, 1, '2021-02-21', '15:20', 10, 1);
+insert into jobs (date_created, customer_id, branch_id , worker_id, visit_on, visit_time, pay_rate, duration) values ('2020-12-09', 2, 22, 2, '2021-02-26', '12:10', 10, 3);
+insert into jobs (date_created, customer_id, branch_id , worker_id, visit_on, visit_time, pay_rate, duration) values ('2021-01-15', 2, 2, 2, '2021-03-08', '10:00', 10, 1);
+insert into jobs (date_created, customer_id, branch_id , worker_id, visit_on, visit_time, pay_rate, duration) values ('2021-01-15', 3, 23, 2, '2021-03-04', '12:45', 10, 1);
+insert into jobs (date_created, customer_id, branch_id , worker_id, visit_on, visit_time, pay_rate, duration) values ('2020-12-09', 3, 3, 7, '2021-03-12', '15:20', 10.5, 2);
+insert into jobs (date_created, customer_id, branch_id , worker_id, visit_on, visit_time, pay_rate, duration) values ('2020-12-09', 4, 4, 3, '2021-03-02', '15:20', 10.5, 2);


### PR DESCRIPTION
### Proposal
Changed `duration` field in the `branches` and `jobs` tables by default to be of value 1. Now `duration` predictably will always be set everywhere to 1 or any other integer value.

Also updated inserted jobs data in the `spring_action_cleaning.sql` file to see more recent jobs. Will need to repopulate our production database with updated queries.

### Checklist

- [x] I have made this pull request to the `master` branch
- [x] I have run `npm run lint` and there are no errors
