### PR TITLE
Style tweaks

### DIFF
--- a/client/src/components/CreateJob/PayRateInput.js
+++ b/client/src/components/CreateJob/PayRateInput.js
@@ -11,7 +11,7 @@ const PayRateInput = ({ state, setState, error }) => {
 	};
 
 	return (
-		<div className="mb-3 mb-md-4 mb-lg-5 w-100 ml-3 ml-md-5">
+		<div className="mb-3 mb-md-4 mb-lg-5 w-100 ml-sm-3 ml-md-5">
 			<FormGroup>
 				<Label for="payRate" size="lg">
 					Pay rate <span className="text-muted">(optional)</span>

--- a/client/src/components/CreateJob/SelectEndTime.js
+++ b/client/src/components/CreateJob/SelectEndTime.js
@@ -18,7 +18,7 @@ const SelectEndTime = ({ state, setState, error }) => {
 	};
 
 	return (
-		<div className="w-100 ml-3 ml-md-5">
+		<div className="w-100 ml-sm-3 ml-md-5">
 			<FormGroup>
 				<Label for="endTime" size="lg">
 					End time <span className="text-muted">(optional)</span>

--- a/client/src/components/CreateJob/SelectTime.js
+++ b/client/src/components/CreateJob/SelectTime.js
@@ -11,7 +11,7 @@ const SelectTime = ({ state, setState, error }) => {
 	};
 
 	return (
-		<div className="mb-3 mb-md-4 mb-lg-5 w-100 ml-3 ml-md-5">
+		<div className="mb-3 mb-md-4 mb-lg-5 w-100 ml-sm-3 ml-md-5">
 			<FormGroup>
 				<Label for="time" size="lg">
 					Visit time

--- a/client/src/components/Reports/CreateBranchReport.js
+++ b/client/src/components/Reports/CreateBranchReport.js
@@ -38,7 +38,7 @@ const CreateBranchReport = () => {
 				forReport={true}
 			/>
 			<SelectBranch state={state} setState={setState} forReport={true} />
-			<div className="d-sm-flex justify-content-between">
+			<div className="d-sm-flex justify-content-between mb-5 mb-sm-0">
 				<SelectDateU
 					state={state}
 					setState={setState}
@@ -51,18 +51,23 @@ const CreateBranchReport = () => {
 					dateAttribute="finish_date"
 					attributeTitle="Finish date"
 				/>
-				<Label check className="d-flex align-items-center">
+			</div>
+			<div className="d-flex justify-content-between justify-content-sm-end flex-sm-column">
+				<Label
+					check
+					className="d-flex align-items-center user-select-none pl-4 text-right align-self-sm-end mb-sm-3 mb-md-4 mb-lg-5"
+					size="lg"
+				>
 					<Input
 						name="detailed"
 						type="checkbox"
 						onChange={handleChange}
 						checked={state.detailed}
-					/>{" "}
+						className="mb-1"
+					/>
 					Detailed
 				</Label>
-			</div>
-			<div className="d-flex justify-content-end">
-				<Button>Run</Button>
+				<Button className="align-self-sm-end">Run</Button>
 			</div>
 		</Form>
 	);

--- a/client/src/components/Reports/CreateCustomerReport.js
+++ b/client/src/components/Reports/CreateCustomerReport.js
@@ -30,7 +30,7 @@ const CreateCustomerReport = () => {
 	return (
 		<Form onSubmit={handleSubmit}>
 			<SelectCustomer state={state} setState={setState} forReport={true} />
-			<div className="d-sm-flex justify-content-between">
+			<div className="d-sm-flex justify-content-between mb-5 mb-sm-0">
 				<SelectDateU
 					state={state}
 					setState={setState}
@@ -43,18 +43,23 @@ const CreateCustomerReport = () => {
 					dateAttribute="finish_date"
 					attributeTitle="Finish date"
 				/>
-				<Label check className="d-flex align-items-center">
+			</div>
+			<div className="d-flex justify-content-between justify-content-sm-end flex-sm-column">
+				<Label
+					check
+					className="d-flex align-items-center user-select-none pl-4 text-right align-self-sm-end mb-sm-3 mb-md-4 mb-lg-5"
+					size="lg"
+				>
 					<Input
 						name="detailed"
 						type="checkbox"
 						onChange={handleChange}
 						checked={state.detailed}
-					/>{" "}
+						className="mb-1"
+					/>
 					Detailed
 				</Label>
-			</div>
-			<div className="d-flex justify-content-end">
-				<Button>Run</Button>
+				<Button className="align-self-sm-end">Run</Button>
 			</div>
 		</Form>
 	);

--- a/client/src/components/Reports/CreateWorkerReport.js
+++ b/client/src/components/Reports/CreateWorkerReport.js
@@ -30,7 +30,7 @@ const CreateWorkerReport = () => {
 	return (
 		<Form onSubmit={handleSubmit}>
 			<SelectWorker state={state} setState={setState} forReport={true} />
-			<div className="d-sm-flex justify-content-between">
+			<div className="d-sm-flex justify-content-between mb-5 mb-sm-0">
 				<SelectDateU
 					state={state}
 					setState={setState}
@@ -43,18 +43,23 @@ const CreateWorkerReport = () => {
 					dateAttribute="finish_date"
 					attributeTitle="Finish date"
 				/>
-				<Label check className="d-flex align-items-center">
+			</div>
+			<div className="d-flex justify-content-between justify-content-sm-end flex-sm-column">
+				<Label
+					check
+					className="d-flex align-items-center user-select-none pl-4 text-right align-self-sm-end mb-sm-3 mb-md-4 mb-lg-5"
+					size="lg"
+				>
 					<Input
 						name="detailed"
 						type="checkbox"
 						onChange={handleChange}
 						checked={state.detailed}
-					/>{" "}
+						className="mb-1"
+					/>
 					Detailed
 				</Label>
-			</div>
-			<div className="d-flex justify-content-end">
-				<Button>Run</Button>
+				<Button className="align-self-sm-end">Run</Button>
 			</div>
 		</Form>
 	);

--- a/client/src/components/Reports/GeneralReport.js
+++ b/client/src/components/Reports/GeneralReport.js
@@ -15,7 +15,7 @@ const CreateGeneralReport = () => {
 
 	return (
 		<Form onSubmit={handleSubmit}>
-			<div className="d-sm-flex justify-content-between">
+			<div className="d-sm-flex justify-content-between mb-5">
 				<SelectDateU
 					state={state}
 					setState={setState}

--- a/client/src/components/Reports/SelectDateU.js
+++ b/client/src/components/Reports/SelectDateU.js
@@ -17,7 +17,13 @@ const SelectDateU = ({
 	};
 
 	return (
-		<div className="mb-3 mb-md-4 mb-lg-5 w-100 mr-3 mr-md-5">
+		<div
+			className={
+				dateAttribute === "start_date"
+					? "w-100 mr-sm-3 mr-md-5"
+					: "w-100 ml-sm-3 ml-md-5"
+			}
+		>
 			<FormGroup>
 				<Label for={dateAttribute} size="lg">
 					{attributeTitle}

--- a/client/src/components/WorkerJobs/WorkerJobInfo.js
+++ b/client/src/components/WorkerJobs/WorkerJobInfo.js
@@ -31,11 +31,11 @@ const WorkerJobInfo = ({
 			</p>
 			<p className="worker-info-text-size">
 				<strong>Contact name: </strong>
-				{contact_name}
+				{contact_name || "—"}
 			</p>
 			<p className="worker-info-text-size">
 				<strong>Contact phone: </strong>
-				{contact_phone}
+				{contact_phone || "—"}
 			</p>
 			<p className="worker-info-text-size">
 				<strong>Planned duration:</strong> {duration}{" "}
@@ -43,7 +43,7 @@ const WorkerJobInfo = ({
 			</p>
 			<p className="worker-info-text-size">
 				<strong>Job details: </strong>
-				{details ? details : "—"}
+				{details || "—"}
 			</p>
 		</div>
 	);

--- a/client/src/pages/CreateJob.js
+++ b/client/src/pages/CreateJob.js
@@ -125,7 +125,7 @@ const Jobs = ({
 				/>
 				<SelectBranch state={state} setState={setState} error={errors.branch} />
 				<SelectWorker state={state} setState={setState} error={errors.worker} />
-				<div className="d-flex justify-content-between">
+				<div className="d-sm-flex justify-content-between">
 					<SelectDate
 						state={state}
 						setState={setState}
@@ -137,7 +137,7 @@ const Jobs = ({
 						error={errors.visit_time}
 					/>
 				</div>
-				<div className="d-flex justify-content-between">
+				<div className="d-sm-flex justify-content-between">
 					<SelectDuration
 						state={state}
 						setState={setState}
@@ -159,7 +159,7 @@ const Jobs = ({
 						These fields should be completed only if the cleaner is unable to
 						log time by himself.
 					</div>
-					<div className="d-flex justify-content-between">
+					<div className="d-sm-flex justify-content-between">
 						<SelectStartTime
 							state={state}
 							setState={setState}


### PR DESCRIPTION
### Proposal
- In `<WorkerJobInfo/ >` component display a long dash ("—") when the contact name or phone is missing instead of an empty string. I thought about not showing them at all in that case but decided to be more explicit (same as with job details, better to display a dash that there are no details than not to display it at all).
- In the job create/edit page wrap inputs to separate rows on small screens.
- Place the "detailed" checkbox on a separate line from the date input fields in all reports pages.

### Checklist

- [x] I have made this pull request to the `master` branch
- [x] I have run `npm run lint` and there are no errors
